### PR TITLE
Add type-safe model names with TypedVoyageAIClient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,19 @@ export * as VoyageAI from "./api";
 export { VoyageAIClient } from "./Client";
 export { VoyageAIEnvironment } from "./environments";
 export { VoyageAIError, VoyageAITimeoutError } from "./errors";
+
+export { TypedVoyageAIClient } from "./typed-client";
+export {
+  EmbedModel,
+  RerankModel,
+  MultimodalEmbedModel,
+  ContextualizedEmbedModel,
+  AnyVoyageModel,
+  TypedEmbedRequest,
+  TypedRerankRequest,
+  TypedMultimodalEmbedRequest,
+  TypedContextualizedEmbedRequest,
+  RECOMMENDED_EMBED_MODELS,
+  RECOMMENDED_RERANK_MODELS,
+  DEPRECATED_EMBED_MODELS
+} from "./models";

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,104 @@
+/**
+ * Type-safe model definitions for VoyageAI SDK
+ * This file provides strongly-typed model names to enhance developer experience
+ * and prevent runtime errors from invalid model names.
+ */
+
+import * as VoyageAI from "./api/index";
+
+// Embedding Models
+export type EmbedModel = 
+  // Latest generation models (recommended)
+  | "voyage-3-large"        // 32K context, best general-purpose and multilingual quality
+  | "voyage-3.5"            // 32K context, optimized general-purpose and multilingual
+  | "voyage-3.5-lite"       // 32K context, optimized for latency and cost
+  | "voyage-3"              // 32K context, general-purpose and multilingual
+  | "voyage-3-lite"         // 32K context, optimized for latency and cost
+  | "voyage-code-3"         // 32K context, optimized for code retrieval
+  
+  // Second generation models
+  | "voyage-finance-2"      // 32K context, optimized for finance
+  | "voyage-law-2"          // 16K context, optimized for legal
+  | "voyage-code-2"         // 16K context, optimized for code (previous gen)
+  | "voyage-multilingual-2" // 32K context, optimized for multilingual
+  | "voyage-large-2-instruct" // 16K context, instruction-tuned (deprecated)
+  | "voyage-large-2"        // 16K context, general-purpose (deprecated)
+  | "voyage-2"              // 4K context, balanced cost/latency/quality (deprecated)
+  
+  // First generation models (deprecated)
+  | "voyage-lite-02-instruct" // 4K context, instruction-tuned (deprecated)
+  | "voyage-02"             // 4K context, pilot v2 (deprecated)
+  | "voyage-01"             // 4K context, v1 (deprecated)
+  | "voyage-lite-01"        // 4K context, v1 lite (deprecated)
+  | "voyage-lite-01-instruct"; // 4K context, v1 instruction-tuned (deprecated)
+
+// Reranking Models
+export type RerankModel = 
+  // Latest generation models (preview)
+  | "rerank-2.5"            // 32K context, generalist optimized for quality
+  | "rerank-2.5-lite"       // 32K context, optimized for latency and quality
+  
+  // Second generation models
+  | "rerank-2"              // 16K context, generalist optimized for quality
+  | "rerank-2-lite"         // 8K context, optimized for latency and quality
+  
+  // First generation models
+  | "rerank-1"              // 8K context, generalist optimized for quality
+  | "rerank-lite-1";        // 4K context, optimized for latency and quality
+
+// Multimodal Embedding Models
+export type MultimodalEmbedModel = 
+  | "voyage-multimodal-3";  // 32K context, rich multimodal embeddings
+
+// Contextualized Embedding Models  
+export type ContextualizedEmbedModel = 
+  | "voyage-context-3";     // 32K context, contextualized chunk embeddings
+
+// Type-safe request interfaces that extend the generated ones
+export interface TypedEmbedRequest extends Omit<VoyageAI.EmbedRequest, 'model'> {
+  model: EmbedModel;
+}
+
+export interface TypedRerankRequest extends Omit<VoyageAI.RerankRequest, 'model'> {
+  model: RerankModel;
+}
+
+export interface TypedMultimodalEmbedRequest extends Omit<VoyageAI.MultimodalEmbedRequest, 'model'> {
+  model: MultimodalEmbedModel;
+}
+
+export interface TypedContextualizedEmbedRequest extends Omit<VoyageAI.ContextualizedEmbedRequest, 'model'> {
+  model: ContextualizedEmbedModel;
+}
+
+// Helper type for all possible models across all endpoints
+export type AnyVoyageModel = EmbedModel | RerankModel | MultimodalEmbedModel | ContextualizedEmbedModel;
+
+// Model categorization helpers
+export const RECOMMENDED_EMBED_MODELS: EmbedModel[] = [
+  "voyage-3-large",
+  "voyage-3.5", 
+  "voyage-3.5-lite",
+  "voyage-3",
+  "voyage-3-lite",
+  "voyage-code-3"
+];
+
+export const RECOMMENDED_RERANK_MODELS: RerankModel[] = [
+  "rerank-2.5",
+  "rerank-2.5-lite",
+  "rerank-2",
+  "rerank-2-lite"
+];
+
+// Deprecated models that should be migrated
+export const DEPRECATED_EMBED_MODELS: EmbedModel[] = [
+  "voyage-large-2-instruct",
+  "voyage-large-2", 
+  "voyage-2",
+  "voyage-lite-02-instruct",
+  "voyage-02",
+  "voyage-01",
+  "voyage-lite-01",
+  "voyage-lite-01-instruct"
+];

--- a/src/typed-client.ts
+++ b/src/typed-client.ts
@@ -1,0 +1,146 @@
+/**
+ * Type-safe wrapper for VoyageAIClient
+ * Provides strongly-typed model names while maintaining full backward compatibility
+ */
+
+import { VoyageAIClient } from "./Client";
+import * as VoyageAI from "./api/index";
+import {
+  TypedEmbedRequest,
+  TypedRerankRequest, 
+  TypedMultimodalEmbedRequest,
+  TypedContextualizedEmbedRequest
+} from "./models";
+
+export class TypedVoyageAIClient extends VoyageAIClient {
+  /**
+   * Type-safe embed method with strongly-typed model names
+   * @param request - Embed request with type-safe model field
+   * @param requestOptions - Request-specific configuration
+   * @returns Promise<VoyageAI.EmbedResponse>
+   * 
+   * @example
+   * ```typescript
+   * await client.embed({
+   *   input: "Hello world",
+   *   model: "voyage-3-large" // TypeScript will autocomplete and validate this
+   * });
+   * ```
+   */
+  public async embed(
+    request: TypedEmbedRequest,
+    requestOptions?: VoyageAIClient.RequestOptions
+  ): Promise<VoyageAI.EmbedResponse> {
+    return super.embed(request, requestOptions);
+  }
+
+  /**
+   * Type-safe rerank method with strongly-typed model names
+   * @param request - Rerank request with type-safe model field  
+   * @param requestOptions - Request-specific configuration
+   * @returns Promise<VoyageAI.RerankResponse>
+   * 
+   * @example
+   * ```typescript
+   * await client.rerank({
+   *   query: "search query",
+   *   documents: ["doc1", "doc2"],
+   *   model: "rerank-2.5" // TypeScript will autocomplete and validate this
+   * });
+   * ```
+   */
+  public async rerank(
+    request: TypedRerankRequest,
+    requestOptions?: VoyageAIClient.RequestOptions
+  ): Promise<VoyageAI.RerankResponse> {
+    return super.rerank(request, requestOptions);
+  }
+
+  /**
+   * Type-safe multimodal embed method with strongly-typed model names
+   * @param request - Multimodal embed request with type-safe model field
+   * @param requestOptions - Request-specific configuration  
+   * @returns Promise<VoyageAI.MultimodalEmbedResponse>
+   * 
+   * @example
+   * ```typescript
+   * await client.multimodalEmbed({
+   *   inputs: [{ content: [{ type: "text", text: "Hello" }] }],
+   *   model: "voyage-multimodal-3" // TypeScript will autocomplete and validate this
+   * });
+   * ```
+   */
+  public async multimodalEmbed(
+    request: TypedMultimodalEmbedRequest,
+    requestOptions?: VoyageAIClient.RequestOptions
+  ): Promise<VoyageAI.MultimodalEmbedResponse> {
+    return super.multimodalEmbed(request, requestOptions);
+  }
+
+  /**
+   * Type-safe contextualized embed method with strongly-typed model names
+   * @param request - Contextualized embed request with type-safe model field
+   * @param requestOptions - Request-specific configuration
+   * @returns Promise<VoyageAI.ContextualizedEmbedResponse>
+   * 
+   * @example  
+   * ```typescript
+   * await client.contextualizedEmbed({
+   *   inputs: [["chunk1", "chunk2"]],
+   *   model: "voyage-context-3" // TypeScript will autocomplete and validate this
+   * });
+   * ```
+   */
+  public async contextualizedEmbed(
+    request: TypedContextualizedEmbedRequest,
+    requestOptions?: VoyageAIClient.RequestOptions
+  ): Promise<VoyageAI.ContextualizedEmbedResponse> {
+    return super.contextualizedEmbed(request, requestOptions);
+  }
+
+  // Legacy methods that accept string models (for backward compatibility)
+  
+  /**
+   * Legacy embed method that accepts string model names (backward compatibility)
+   * @deprecated Use the typed embed method for better type safety
+   */
+  public async embedLegacy(
+    request: VoyageAI.EmbedRequest,
+    requestOptions?: VoyageAIClient.RequestOptions
+  ): Promise<VoyageAI.EmbedResponse> {
+    return super.embed(request, requestOptions);
+  }
+
+  /**
+   * Legacy rerank method that accepts string model names (backward compatibility)
+   * @deprecated Use the typed rerank method for better type safety
+   */
+  public async rerankLegacy(
+    request: VoyageAI.RerankRequest,
+    requestOptions?: VoyageAIClient.RequestOptions
+  ): Promise<VoyageAI.RerankResponse> {
+    return super.rerank(request, requestOptions);
+  }
+
+  /**
+   * Legacy multimodal embed method that accepts string model names (backward compatibility)
+   * @deprecated Use the typed multimodalEmbed method for better type safety
+   */
+  public async multimodalEmbedLegacy(
+    request: VoyageAI.MultimodalEmbedRequest,
+    requestOptions?: VoyageAIClient.RequestOptions
+  ): Promise<VoyageAI.MultimodalEmbedResponse> {
+    return super.multimodalEmbed(request, requestOptions);
+  }
+
+  /**
+   * Legacy contextualized embed method that accepts string model names (backward compatibility)
+   * @deprecated Use the typed contextualizedEmbed method for better type safety
+   */
+  public async contextualizedEmbedLegacy(
+    request: VoyageAI.ContextualizedEmbedRequest,
+    requestOptions?: VoyageAIClient.RequestOptions
+  ): Promise<VoyageAI.ContextualizedEmbedResponse> {
+    return super.contextualizedEmbed(request, requestOptions);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds strongly-typed model names for all VoyageAI endpoints to prevent runtime errors from invalid model strings
- Introduces `TypedVoyageAIClient` with full TypeScript autocomplete and validation
- Maintains 100% backward compatibility with existing `VoyageAIClient`

## What's New
- **Type-safe model definitions** (`EmbedModel`, `RerankModel`, etc.) with all current models
- **TypedVoyageAIClient** - wrapper providing compile-time model validation
- **Enhanced DX** - IDE autocomplete for model names prevents typos
- **Future-proof** - won't be overwritten by SDK regeneration

## Model Coverage
- **Embedding models**: voyage-3-large, voyage-3.5, voyage-code-3, etc. (16 models)
- **Reranking models**: rerank-2.5, rerank-2, rerank-lite-1, etc. (6 models)
- **Multimodal**: voyage-multimodal-3
- **Contextualized**: voyage-context-3

## Usage Examples
```typescript
// New: Type-safe with autocomplete
import { TypedVoyageAIClient } from "voyageai";
const client = new TypedVoyageAIClient({ apiKey: "key" });
await client.embed({
  input: "text",
  model: "voyage-3-large" // ✅ Autocomplete + validation
});

// Existing: Still works unchanged
import { VoyageAIClient } from "voyageai";
const client = new VoyageAIClient({ apiKey: "key" });
await client.embed({ input: "text", model: "voyage-3-large" }); // ✅ No changes
