### PR TITLE
Fix ESM bare directory imports causing ERR_UNSUPPORTED_DIR_IMPORT

### DIFF
--- a/scripts/rename-to-esm-files.js
+++ b/scripts/rename-to-esm-files.js
@@ -44,6 +44,30 @@ async function updateFiles(files) {
     console.log(`Updated imports in ${updatedFiles.length} files.`);
 }
 
+async function resolveBarePath(file, importPath) {
+    const dir = path.dirname(file);
+    const resolved = path.resolve(dir, importPath);
+
+    // Check if it's a directory with an index file
+    try {
+        const stat = await fs.stat(resolved);
+        if (stat.isDirectory()) {
+            return `${importPath}/index.mjs`;
+        }
+    } catch {}
+
+    // Check if a corresponding .js or .mjs file exists
+    for (const ext of [".mjs", ".js"]) {
+        try {
+            await fs.stat(resolved + ext);
+            return `${importPath}.mjs`;
+        } catch {}
+    }
+
+    // If nothing matched, leave it unchanged
+    return importPath;
+}
+
 async function updateFileContents(file) {
     const content = await fs.readFile(file, "utf8");
 
@@ -60,6 +84,38 @@ async function updateFileContents(file) {
             "g",
         );
         newContent = newContent.replace(dynamicRegex, `$1("$2${newExt}")`);
+    }
+
+    // Handle bare imports (no file extension) — these need resolution
+    const allExtensions = [...Object.keys(extensionMap), ...Object.values(extensionMap)];
+    const bareStaticRegex = /(import|export)(.+from\s+['"])(\.\.?\/[^'"]+)(['"])/g;
+    const matches = [...newContent.matchAll(bareStaticRegex)];
+    for (const match of matches.reverse()) {
+        const importPath = match[3];
+        // Skip if it already has a known extension
+        if (allExtensions.some((ext) => importPath.endsWith(ext))) continue;
+
+        const resolved = await resolveBarePath(file, importPath);
+        if (resolved !== importPath) {
+            const start = match.index;
+            const end = start + match[0].length;
+            newContent = `${newContent.slice(0, start)}${match[1]}${match[2]}${resolved}${match[4]}${newContent.slice(end)}`;
+        }
+    }
+
+    // Handle bare dynamic imports (no file extension)
+    const bareDynamicRegex = /(yield\s+import|await\s+import|import)\s*\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g;
+    const dynMatches = [...newContent.matchAll(bareDynamicRegex)];
+    for (const match of dynMatches.reverse()) {
+        const importPath = match[2];
+        if (allExtensions.some((ext) => importPath.endsWith(ext))) continue;
+
+        const resolved = await resolveBarePath(file, importPath);
+        if (resolved !== importPath) {
+            const start = match.index;
+            const end = start + match[0].length;
+            newContent = `${newContent.slice(0, start)}${match[1]}("${resolved}")${newContent.slice(end)}`;
+        }
     }
 
     if (content !== newContent) {


### PR DESCRIPTION
## Summary

- Fixes the ESM build script (`scripts/rename-to-esm-files.js`) to resolve bare directory/file imports that lack file extensions
- Directory imports (e.g. `../api`) are rewritten to `../api/index.mjs`
- File imports (e.g. `../Client`) are rewritten to `../Client.mjs`
- The existing regex only handled imports already ending in `.js`, leaving extensionless imports untouched

Fixes #26

## Test plan

- [x] `pnpm build` succeeds with no bare imports remaining in `dist/esm/`
- [x] ESM import works: `node -e "import { VoyageAIClient } from 'voyageai'" --input-type=module`
- [x] CJS import still works: `node -e "const { VoyageAIClient } = require('voyageai')"`
- [x] `pnpm test:unit` — all 421 tests pass
- [x] `pnpm run check` — no new lint issues introduced