### PR TITLE
fix: resolve bare directory imports in ESM build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "voyageai",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "private": false,
     "repository": {
         "type": "git",

--- a/scripts/rename-to-esm-files.js
+++ b/scripts/rename-to-esm-files.js
@@ -44,6 +44,24 @@ async function updateFiles(files) {
     console.log(`Updated imports in ${updatedFiles.length} files.`);
 }
 
+function resolveBarePath(importPath, fromFile) {
+    const dir = path.dirname(fromFile);
+    const resolved = path.resolve(dir, importPath);
+    try {
+        const stat = require("fs").statSync(resolved);
+        if (stat.isDirectory()) {
+            return importPath + "/index.mjs";
+        }
+    } catch {}
+    for (const ext of [".js", ".ts", ".mjs", ".mts"]) {
+        try {
+            require("fs").statSync(resolved + ext);
+            return importPath + ".mjs";
+        } catch {}
+    }
+    return null;
+}
+
 async function updateFileContents(file) {
     const content = await fs.readFile(file, "utf8");
 
@@ -61,6 +79,15 @@ async function updateFileContents(file) {
         );
         newContent = newContent.replace(dynamicRegex, `$1("$2${newExt}")`);
     }
+
+    // Resolve bare relative imports (no file extension) to explicit .mjs paths
+    const bareStaticRegex = /(import|export)(.+from\s+['"])(\.\.?\/[^'"]+)(?<!\.\w+)(['"])/g;
+    newContent = newContent.replace(bareStaticRegex, (match, keyword, middle, importPath, quote) => {
+        if (/\.\w+$/.test(importPath)) return match;
+        const resolved = resolveBarePath(importPath, file);
+        if (resolved) return `${keyword}${middle}${resolved}${quote}`;
+        return match;
+    });
 
     if (content !== newContent) {
         await fs.writeFile(file, newContent, "utf8");


### PR DESCRIPTION
## Summary

- Fixed `ERR_UNSUPPORTED_DIR_IMPORT` when importing `voyageai` from Node.js ESM projects
- The existing `scripts/rename-to-esm-files.js` post-build script only rewrote imports that already had `.js` extensions (`.js` → `.mjs`), but custom code in `src/extended/` and `src/local/` uses bare extensionless imports (e.g. `export * from "../api"`) which Node's ESM resolver rejects
- Added a resolution step that detects bare relative imports and resolves them to explicit `.mjs` paths (directory → `/index.mjs`, file → `.mjs`)

## Test plan

- [x] `npm run build` succeeds
- [x] All 421 unit tests pass
- [x] ESM import verified: `import { VoyageAIClient } from "voyageai"` works in a `"type": "module"` project
- [x] CJS import verified: `require("voyageai")` still works
- [x] Zero bare extensionless imports remain in `dist/esm/**/*.mjs`

Closes #26, closes #29