### PR TITLE
chore: extend bare import resolution extensions and bump to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "voyageai",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "private": false,
     "repository": {
         "type": "git",

--- a/scripts/rename-to-esm-files.js
+++ b/scripts/rename-to-esm-files.js
@@ -57,7 +57,7 @@ async function resolveBarePath(file, importPath) {
     } catch {}
 
     // Check if a corresponding .js or .mjs file exists
-    for (const ext of [".mjs", ".js"]) {
+    for (const ext of [".mjs", ".js", ".mts", ".ts"]) {
         try {
             await fs.stat(resolved + ext);
             return `${importPath}.mjs`;


### PR DESCRIPTION
## Summary

- Extends `resolveBarePath` in `scripts/rename-to-esm-files.js` to also check `.ts` and `.mts` extensions (in addition to `.mjs` and `.js`)
- Bumps version to 0.3.0

Follows up on #27 which fixed the core ESM bare import issue.

## Test plan

- [x] `npm run build` succeeds
- [x] ESM import verified in standalone `"type": "module"` TypeScript project
- [x] CJS import still works