### PR TITLE
fix: use explicit .js extensions in custom source imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "voyageai",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "private": false,
     "repository": {
         "type": "git",

--- a/src/extended/ExtendedClient.ts
+++ b/src/extended/ExtendedClient.ts
@@ -2,13 +2,13 @@
  * Extended VoyageAI client with local model support
  */
 
-import { VoyageAIClient as GeneratedClient } from "../Client";
-import type * as VoyageAI from "../api";
-import { HttpResponsePromise } from "../core/fetcher/HttpResponsePromise";
-import { unknownRawResponse } from "../core/fetcher/RawResponse";
-import { localEmbed, isLocalModel } from "../local";
-import { tokenizeTexts } from "../local/tokenizer";
-import type { TokenizeResult } from "../local/tokenizer";
+import { VoyageAIClient as GeneratedClient } from "../Client.js";
+import type * as VoyageAI from "../api/index.js";
+import { HttpResponsePromise } from "../core/fetcher/HttpResponsePromise.js";
+import { unknownRawResponse } from "../core/fetcher/RawResponse.js";
+import { localEmbed, isLocalModel } from "../local/index.js";
+import { tokenizeTexts } from "../local/tokenizer.js";
+import type { TokenizeResult } from "../local/tokenizer.js";
 
 export class VoyageAIClient extends GeneratedClient {
     /**

--- a/src/extended/index.ts
+++ b/src/extended/index.ts
@@ -1,13 +1,13 @@
 // Re-export everything from generated SDK
-export * from "../api";
-export * from "../errors";
+export * from "../api/index.js";
+export * from "../errors/index.js";
 
 // Export our extended client as the main one
-export { VoyageAIClient } from "./ExtendedClient";
+export { VoyageAIClient } from "./ExtendedClient.js";
 
 // For advanced users who want the original generated client
-export { VoyageAIClient as GeneratedVoyageAIClient } from "../Client";
+export { VoyageAIClient as GeneratedVoyageAIClient } from "../Client.js";
 
 // Export local utilities for advanced use cases
-export { localEmbed, isLocalModel } from "../local";
-export type { TokenizeResult } from "../local/tokenizer";
+export { localEmbed, isLocalModel } from "../local/index.js";
+export type { TokenizeResult } from "../local/tokenizer.js";

--- a/src/local/index.ts
+++ b/src/local/index.ts
@@ -1,11 +1,11 @@
-export { localEmbed } from "./local-embedder";
-export { getTokenizerForModel, tokenizeTexts } from "./tokenizer";
-export type { TokenizeResult } from "./tokenizer";
+export { localEmbed } from "./local-embedder.js";
+export { getTokenizerForModel, tokenizeTexts } from "./tokenizer.js";
+export type { TokenizeResult } from "./tokenizer.js";
 export {
     isLocalModel,
     getModelConfig,
     validateDimension,
     validatePrecision,
     SUPPORTED_MODELS,
-} from "./model-registry";
-export type { LocalModelConfig } from "./model-registry";
+} from "./model-registry.js";
+export type { LocalModelConfig } from "./model-registry.js";

--- a/src/local/local-embedder.ts
+++ b/src/local/local-embedder.ts
@@ -3,9 +3,9 @@
  * Runs voyage-4-nano entirely locally - no API calls after initial model download.
  */
 
-import type * as VoyageAI from "../api";
-import { getModelConfig, validateDimension, validatePrecision } from "./model-registry";
-import { getTransformers, getTokenizerForModel } from "./tokenizer";
+import type * as VoyageAI from "../api/index.js";
+import { getModelConfig, validateDimension, validatePrecision } from "./model-registry.js";
+import { getTransformers, getTokenizerForModel } from "./tokenizer.js";
 
 // Cached pipelines (persist across calls)
 const pipelineCache = new Map<string, any>();


### PR DESCRIPTION
## Summary

- Adds explicit `.js` extensions to all imports in `src/extended/` and `src/local/` (the `.fernignore`-protected custom code)
- Matches the convention Fern's generated code already uses, so the existing `rename-to-esm-files.js` script handles `.js` → `.mjs` rewriting correctly
- Makes the ESM fix **resilient to Fern regeneration** — the rename script can be freely overwritten without reintroducing the bare import bug

## Why

PR #27 fixed the ESM bare import issue by patching `scripts/rename-to-esm-files.js`, but that file is Fern-managed (not in `.fernignore`). On the next Fern regeneration, the fix would be overwritten. This PR fixes the root cause in the custom source files instead.

## Test plan

- [x] `npm run build` succeeds
- [x] Zero bare imports in `dist/esm/**/*.mjs`
- [x] ESM import verified in standalone `"type": "module"` TypeScript project
- [x] CJS import still works
- [x] 514 unit/local tests pass (75 skipped — integration tests requiring API key)